### PR TITLE
Correct parameter list in staypoint

### DIFF
--- a/genomeapi/api/stay_point.py
+++ b/genomeapi/api/stay_point.py
@@ -20,6 +20,6 @@
 from .basic_query import BasicQuery
 
 class StayPoint(BasicQuery):
-  def __init__(self, URL=URL, token, proxies: dict={}):
+  def __init__(self, URL, token, proxies: dict={}):
     super().__init__(end_point='staypoint', URL=URL, token=token, proxies=proxies)
 


### PR DESCRIPTION
Inclusion of non-default parameter in staypoint constructor results in errors in some environments when running Dspark().